### PR TITLE
Csv Import bulk insert solution for larger csv file

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -63,9 +63,19 @@ class BlogsController < ApplicationController
 
   def import
     file = params[:attachment]
-    BulkImportBlogsService.new(10_000, file, current_user.id).process
-    # End code to handle CSV data
-    redirect_to blogs_path, notice: "Blog uploaded successfully."
+  
+    if file.present?
+      # Save the file temporarily in `tmp/` so the background job can access it
+      temp_path = Rails.root.join('tmp', "import_#{Time.now}.csv")
+      File.open(temp_path, 'wb') { |f| f.write(file.read) }
+  
+      # Enqueue the background job with the file path and user ID
+      BulkImportBlogsJob.perform_later(10000, temp_path, current_user.id)
+  
+      redirect_to blogs_path, notice: "Blog upload started. You will be notified when it's done."
+    else
+      redirect_to blogs_path, alert: "Please upload a valid CSV file."
+    end
   end
 
   private

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -63,15 +63,9 @@ class BlogsController < ApplicationController
 
   def import
     file = params[:attachment]
-    data = CSV.parse(file.to_io, headers: true, encoding: 'utf8')
-    # Start code to handle CSV data
-    ActiveRecord::Base.transaction do
-      data.each do |row|
-        current_user.blogs.create!(row.to_h)
-      end
-    end
+    BulkImportBlogsService.new(10_000, file, current_user.id).process
     # End code to handle CSV data
-    redirect_to blogs_path
+    redirect_to blogs_path, notice: "Blog uploaded successfully."
   end
 
   private

--- a/app/jobs/bulk_import_blogs_job.rb
+++ b/app/jobs/bulk_import_blogs_job.rb
@@ -1,0 +1,16 @@
+class BulkImportBlogsJob < ApplicationJob
+  queue_as :default
+
+  def perform(batch_size, file_path, user_id)
+    # Do something later
+    if File.exist?(file_path)
+      # Call the service to process the file
+      BulkImportBlogsService.new(batch_size, file_path, user_id).process
+
+      # Delete the file after processing to save space
+      File.delete(file_path) if File.exist?(file_path)
+    else
+      Rails.logger.error "File not found: #{file_path}"
+    end
+  end
+end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -1,4 +1,6 @@
 class Blog < ApplicationRecord
   belongs_to :user
   has_many :api_responses
+
+  validates :title, :body, presence: true
 end

--- a/app/services/bulk_import_blogs_service.rb
+++ b/app/services/bulk_import_blogs_service.rb
@@ -1,0 +1,68 @@
+require 'csv'
+
+class BulkImportBlogsService
+
+  def initialize(batch_size, file_path, user_id)
+    @batch_size = batch_size      
+    @file_path = file_path    
+    @user_id = user_id        
+  end
+
+  def process
+    blogs_data = []      
+    invalid_blogs = []   
+    # Read CSV file line by line instead of loading the whole file
+    CSV.foreach(@file_path, headers: true, encoding: 'utf8') do |row|
+      # Validate the row before adding it to the blogs_data array
+      if check_blog_valid?(row)
+        blogs_data << row.to_h.merge(
+          user_id: @user_id, 
+          created_at: Time.now, 
+          updated_at: Time.now
+        )
+      else
+        # Store invalid records for logging
+        invalid_blogs << row.to_h  
+      end
+      # If batch size is reached, insert and log in bulk
+      handle_bulk_insert_and_logging(blogs_data, invalid_blogs) if blogs_data.size >= @batch_size
+    end
+    # Insert and log remaining records after finishing CSV processing
+    handle_bulk_insert_and_logging(blogs_data, invalid_blogs)
+  end
+  
+  private
+
+  # Checks if a blog record is valid
+  def check_blog_valid?(row)
+    blog = Blog.new(row.to_h.merge(user_id: @user_id))
+    blog.valid?  
+  end
+
+  # Performs bulk insert of valid blog records
+  def bulk_insert_blogs(blogs_data)
+    ActiveRecord::Base.transaction do
+      Blog.insert_all(blogs_data)  
+    end
+    blogs_data.clear  
+  end
+
+  # Logs invalid blog records into a CSV file
+  def log_invalid_blogs(invalid_blogs)
+    error_log_file = Rails.root.join('log', "invalid_blogs_#{Time.current.to_i}.csv")
+
+    CSV.open(error_log_file, "a") do |csv|
+      # Write headers only if the file is empty
+      csv << ["Title", "Body", "User ID", "Errors"] if File.zero?(error_log_file)
+      invalid_blogs.each { |record| csv << record }
+    end
+    invalid_blogs.clear  
+  end
+
+  # Handles both bulk inserting valid blogs and logging invalid ones
+  def handle_bulk_insert_and_logging(blogs_data, invalid_blogs)
+    bulk_insert_blogs(blogs_data) unless blogs_data.empty?    
+    log_invalid_blogs(invalid_blogs) unless invalid_blogs.empty?
+  end
+
+end


### PR DESCRIPTION
I have optimized csv reading task by using techniques

**Solution 1:** (When user does not wants to process csv file in the background)
* I have first converted CSV import logic to a Service to follow single responsability pattern
* I have then read csv file one by one instead of loading the whole file in memory
* I have then make two arrays for storing validated blogs and invalidate blogs to keep track of record as well so that we can see which records was validated and which are not
* I have then bulk inserted record in db using insert_all instead of inserting. records one by one to db for each batch size
* I have then created a file in logs directory for storing invalidated records.
* In this way I have solved the problem of memory overflow and too much queries.

**Solution 2** : (When user is comfortable in running the file in the background)
* I have stored the file temporarily in the tmp folder of our application
* I have then created a background job and perform_later to run it in the background
* This job will call the same service with a batch size and process the csv file

**Summary:** 
I have taken care optimizing service to ensure memory overflow does not occur and to check if our file is processed successfully or not I have handled both valid and invalid record in CSV files.